### PR TITLE
closing the session after each query here should reduce queue pool risk

### DIFF
--- a/lot-availability-api/application.py
+++ b/lot-availability-api/application.py
@@ -93,6 +93,7 @@ def get_lot_info(id):
 def get_lot_polling(id):
     while True:
         updated_lot = db.session.query(Spots).filter_by(lot_id=id).all()
+        db.session.close()
         updated_rows = []
         rows = []
         for row in updated_lot:


### PR DESCRIPTION
so the queue pool error we were getting is related to never closing the db session in the polling loop. since flask automatically destroys session connections when responses are sent back, we never ran into this before. however, if we left the polling endpoint open for a long time without changes, we'd eventually get a queue pool error. so, closing the connection after we query each time will prevent this from happening.